### PR TITLE
Fix Mypy Configuration

### DIFF
--- a/indico_toolkit/client.py
+++ b/indico_toolkit/client.py
@@ -8,7 +8,7 @@ from .retry import retry
 
 
 @retry(IndicoRequestError, ConnectionError)
-def create_client(
+def create_client(  # type: ignore[no-any-unimported]
     host: str,
     api_token_path: "str | None" = None,
     api_token_string: "str | None" = None,

--- a/indico_toolkit/polling/autoreview.py
+++ b/indico_toolkit/polling/autoreview.py
@@ -3,8 +3,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from indico import AsyncIndicoClient, IndicoConfig  # type: ignore[import-untyped]
-from indico.queries import (  # type: ignore[import-untyped]
+from indico import AsyncIndicoClient, IndicoConfig
+from indico.queries import (
     GetSubmission,
     JobStatus,
     RetrieveStorageObject,
@@ -41,7 +41,7 @@ class AutoReviewPoller:
     and submits the review results concurrently.
     """
 
-    def __init__(
+    def __init__(  # type: ignore[no-any-unimported]
         self,
         config: IndicoConfig,
         workflow_id: int,

--- a/indico_toolkit/polling/downstream.py
+++ b/indico_toolkit/polling/downstream.py
@@ -2,12 +2,12 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
-from indico import AsyncIndicoClient, IndicoConfig  # type: ignore[import-untyped]
-from indico.queries import (  # type: ignore[import-untyped]
+from indico import AsyncIndicoClient, IndicoConfig
+from indico.queries import (
     GetSubmission,
     UpdateSubmission,
 )
-from indico.types import Submission  # type: ignore[import-untyped]
+from indico.types import Submission
 
 from ..retry import retry
 from .queries import SubmissionIdsPendingDownstream
@@ -29,7 +29,7 @@ class DownstreamPoller:
     them concurrently, and marks them as retrieved.
     """
 
-    def __init__(
+    def __init__(  # type: ignore[no-any-unimported]
         self,
         config: IndicoConfig,
         workflow_id: int,

--- a/indico_toolkit/polling/queries.py
+++ b/indico_toolkit/polling/queries.py
@@ -1,12 +1,12 @@
 from typing import TYPE_CHECKING
 
-from indico.queries import GraphQLRequest  # type: ignore[import-untyped]
+from indico.queries import GraphQLRequest
 
 if TYPE_CHECKING:
     from typing import Any
 
 
-class SubmissionIdsPendingAutoReview(GraphQLRequest):  # type: ignore[misc]
+class SubmissionIdsPendingAutoReview(GraphQLRequest):  # type: ignore[misc, no-any-unimported]
     QUERY = """
     query SubmissionIdsPendingAutoReview($workflowIds: [Int]) {
         submissions(
@@ -33,7 +33,7 @@ class SubmissionIdsPendingAutoReview(GraphQLRequest):  # type: ignore[misc]
         }
 
 
-class SubmissionIdsPendingDownstream(GraphQLRequest):  # type: ignore[misc]
+class SubmissionIdsPendingDownstream(GraphQLRequest):  # type: ignore[misc, no-any-unimported]
     QUERY = """
     query SubmissionIdsPendingDownstream($workflowIds: [Int]) {
         submissions(

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
-[mypy]
 #
-# pyproject.toml contains the main configuration for mypy, which applies to existing
-# modules that are type hinted and any new modules that are added.
+# pyproject.toml contains the main configuration for mypy, which is copied here as mypy
+# will not merge the configs. This config applies to existing modules that are type
+# hinted and any new modules that are added.
 #
 # This file contains overrides to ignore errors in older modules and dependencies that
 # aren't type hinted, with the intention that these errors are fixed over time so that
@@ -11,6 +11,11 @@
 # address the errors it finds, repeating until the module passes. Once it passes,
 # remove the override from the list and commit the changes.
 #
+[mypy]
+strict = true
+show_error_codes = true
+warn_unreachable = true
+disallow_any_unimported = true
 
 [mypy-indico.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -29,9 +29,6 @@ ignore_errors = True
 [mypy-indico_toolkit.auto_review.*]
 ignore_errors = True
 
-[mypy-indico_toolkit.etloutput.*]
-ignore_errors = True
-
 [mypy-indico_toolkit.indico_wrapper.*]
 ignore_errors = True
 
@@ -42,12 +39,6 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-indico_toolkit.pipelines.*]
-ignore_errors = True
-
-[mypy-indico_toolkit.polling.*]
-ignore_errors = True
-
-[mypy-indico_toolkit.results.*]
 ignore_errors = True
 
 [mypy-indico_toolkit.snapshots.*]

--- a/tests/results/test_predictions.py
+++ b/tests/results/test_predictions.py
@@ -16,7 +16,7 @@ def test_confidence() -> None:
     assert prediction.confidence == 1.0
 
 
-def test_extractions() -> None:
+def test_accepted() -> None:
     prediction = Extraction(
         document=None,  # type: ignore[arg-type]
         model=None,  # type: ignore[arg-type]
@@ -34,6 +34,20 @@ def test_extractions() -> None:
     assert prediction.accepted
     prediction.unaccept()
     assert not prediction.accepted
+
+
+def test_rejected() -> None:
+    prediction = Extraction(
+        document=None,  # type: ignore[arg-type]
+        model=None,  # type: ignore[arg-type]
+        review=None,
+        label="Label",
+        confidences={"Label": 0.5},
+        extras=None,  # type: ignore[arg-type]
+        text="Value",
+        accepted=False,
+        rejected=False,
+    )
 
     prediction.accept()
     prediction.reject()


### PR DESCRIPTION
When I added `mypy.ini` to ignore untyped modules without cluttering up `pyproject.toml`, I effectively removed the mypy configuration altogether. TIL mypy doesn't merge configs from multiple files; it stops at the first one it finds. I also ignored all modules, including the type hinted ones??? ¯\_(ツ)_/¯

This PR fixes that by copying the mypy config values from `pyproject.toml` into `mypy.ini` and unignoring the type hinted modules. It also fixes a couple typing issues now that mypy is actually being run, mostly around usage of the untyped `indico-client`.

There's only one actual code change in the tests to split a long unit test that mypy thinks has unreachable code.