### PR TITLE
Unify Dataclass Loading APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,190 +1,261 @@
 # Changelog
 
-## 1.0.1 - 6/2/2021
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and versions match the minimum IPA version required to use functionality.
+
+
+## [v7.2.0] - 2025-06-17
 
 ### Added
 
-* Added Snapshot merging / manipulation
-* Class for highlighting extractions onto source PDFs and adding table of contents.
-
-### Fixed
-
-* Row Association now also sorting on 'bbtop'
-
-## 1.0.2 6/15/2021
-
-### Added
-
-* PDF manipulation features
-* Support for classification predictions
-
-### Fixed
-
-* Dependency installation
-
-## 1.0.3 8/16/2021
-
-### Added
-
-* Find from questionnaire ID added to finder class.
-* ModelGroupPredict support added.
-* Added module to get metrics for all models in a group.
-* Multi color highlighting and annotations added for PDF highlighting.
-* Added stagger dataset upload feature for large doc datasets.
-* Added default retry functionality for certain API calls.
-* Added additional snapshot features.
-
-### Fixed
-
-* Wait kwarg added to submit review method.
-* Better support for dataset creation / adding files to teach tasks.
-
-## 1.0.5 9/21/2021
-
-### Added
-
-* Classes for model comparison and model improvement.
-* Plotting functionality for model comparison.
-
-## 1.0.7 11/9/2021
-
-### Added
-
-* Positioning class added to assist in relative prediction location validation
-* Added # of samples labeled to metrics class.
-
-### Removed
-
-* Teach classes in indico_wrapper
-
-## 1.0.8 11/15/2021
-
-### Added
-
-* New line plot for number of samples in metrics class.
-* Update to highlighting class with new flexibility and bookmarks replacing table of contents.
-
-## 1.1.1 12/6/2021
-
-### Added
-
-* Abillity to include metadata with highlighter
-* Ability to split large snapshots into smaller files
-
-## 1.1.2 12/6/2021
-
-### Added
-
-* Updated functionality for large dataset creation. Batch options allow for more reliable dataset uploads.
-
-## 1.2 1/6/2022
-
-### Added
-
-* New distance measurements in the prediction Positioning class.
-* New Features on the Extractions class: predictions that are removed by any method are saved in an
-  attribute if they're needed for logs, etc.; get all text values for a particular label; get most
-  common text value for a particular label.
-* Better exception handling for Workflow submissions and more flexibility on format of what is returned
-  (allows custom response jsons to avoid the WorkflowResult class).
-
-## 1.2.2 3/03/2022
-
-### Added
-
-* Updated metrics plot to order ascending based on latest model
-* New feature in Positioning class to calculate overlap between two bounding boxes on the same page
-
-### Fixed
-
-* Optional dependencies to support M1 installation
-
-## 2.0.1 5/20/2022
-
-### Added
-
-* New feature in FileProcessing class to read and return file as json
-* New feature in Highlighter class to redact and replace highlights with spoofed data
-* New Download class to support downloading resources from an Indico Cluster
-* Upgrades client to 5.1.3 and upgrades SDK calls for Indico 5.x compatibility
-
-### Removed
-
-* FindRelated class in indico_wrapper
-
-## 2.0.2 8/31/2022
-
-### Added
-
-* Upgrades client to 5.1.4
-* New feature to now support staggered looped learning
-* Ground truth compare feature to compare a snapshot against model predictions and receive analytics
-* Modifies IndioWrapper class to updated CreateModelGroup call to work with Indico 5.x
-* Updates Snapshot class to account for updated target spans
-* Updates Add Model calls to aligh with 5.1.4 components
-
-## 6.0 10/30/23
-
-This is the first major version release tested to work on Indico 6.X.
-
-### Added
-
-* Refactored AutoReview to simplify setup.
-* Replaced AutoClassifier with AutoPopulator to make ondoc classification model training simple. This class also includes a "copy_teach_task" method that is a frequently needed standalone method.
-* Simplified a StaggeredLoop implementation to inject labeled samples into a dev workflow (deprecated previous version).
-* Added support for unbundling metrics.
-* Added the `Strucure` class to support building out workflows, datasets, teach tasks. As well as to support copying workflows.
-
-## 6.0.1 11/22/23
-
-### Added
-
-* Small but important fix to add original filename to the workflow result object
-
-## 6.1.0 5/6/24
-
-### Removed
-
-* Removed staggered loop support and removed highlighting support.
-
-## 6.14.0 3/10/25
-
-* Added `results` module.
-* Added `etloutput` module.
-* Refactored `retry` decorator with asyncio support.
-* Switched to Poetry for packaging and dependency management.
-
-## 6.14.1 3/20/25
-
-* Improved Poetry and Poe configuration.
-* Update more attributes when prediction text changes to avoid TAK normalization issues.
-
-## 6.14.2 5/8/25
-
-* Fixed Mypy configuration.
-* Removed `AutoPopulator`, `CustomOcr`, `Datasets`, `DocExtraction`, `Reviewer` classes.
-* Added support for imported models using IPA 7.2 `component_metadata` section.
-* Parse and preserve full span information for `Unbundling` predictions.
-* Add `group = next(group)` idiom.
-
-## 7.2.0 6/17/25
-
-### Added
-
-* Unified support for `dict`, JSON `str`, and JSON `bytes` as loadable types in
+- Unified support for `dict`, JSON `str`, and JSON `bytes` as loadable types in
   `results.load()`, `results.load_async()`, `etloutput.load()`, and
   `etloutput.load_async()`.
 
 ### Changed
 
-* Renamed `model`, `ModelGroup`, and `ModelGroupType` to `task`, `Task`, and `TaskType`
+- Rename `model`, `ModelGroup`, and `ModelGroupType` to `task`, `Task`, and `TaskType`
   in the `results` module.
-* Table OCR is now automatically loaded when present
+- Table OCR is automatically loaded when present
   (`AutoReviewPoller(..., load_tables=True)` and `etloutput.load(..., tables=True)` are
   now the default).
 
 ### Removed
 
-* v1 result file code paths in the `results` module.
-* v1 ETL output code paths in the `etloutput` module.
-* 6.X edge cases in the `results` module.
+- v1 result file support and code paths in the `results` module.
+- v1 ETL output support and code paths in the `etloutput` module.
+- IPA 6.X support and edge cases in the `results` and `etloutput` modules.
+
+
+## [v6.14.2] - 2025-05-08
+
+### Added
+
+- Support for imported models using IPA 7.2 `component_metadata` section.
+- Parse and preserve full span information for `Unbundling` predictions.
+- `group = next(group)` idiom.
+
+### Removed
+
+- `AutoPopulator`, `CustomOcr`, `Datasets`, `DocExtraction`, `Reviewer` classes.
+
+### Fixed
+
+- Mypy configuration.
+
+
+## [v6.14.1] - 2025-03-20
+
+### Changed
+
+- Improve Poetry and Poe configuration.
+- Update more attributes when prediction text changes to avoid TAK normalization issues.
+
+
+## [v6.14.0] - 2025-03-10
+
+### Added
+
+- `results` module.
+- `etloutput` module.
+- Async coroutine support in the `retry` decorator.
+
+### Changed
+
+- Switch to Poetry for packaging and dependency management.
+
+
+## v6.1.0 - 2024-05-06
+
+### Removed
+
+- Staggered loop support.
+- Highlighting support.
+
+
+## v6.0.1 - 2023-11-22
+
+### Added
+
+- Original filename to the workflow result object.
+
+
+## v6.0.0 - 2023-10-30
+
+This is the first major version release tested to work on Indico 6.X.
+
+### Added
+
+- Support for unbundling metrics.
+- `Structure` class to support building out workflows, datasets, teach tasks, and
+  copying workflows.
+
+### Changed
+
+- Refactor `AutoReview` to simplify setup.
+- Replace `AutoClassifier` with `AutoPopulator` to make on-document classification
+  model training simple. This class also includes a "copy_teach_task" method that is a
+  frequently needed standalone method.
+- Simplify `StaggeredLoop` implementation to inject labeled samples into a development
+  workflow (deprecated previous version).
+
+
+## v2.0.2 - 2022-08-31
+
+### Added
+
+- Support for staggered looped learning.
+- Ground truth compare feature to compare a snapshot against model predictions and
+  receive analytics.
+
+### Changed
+
+- Upgrade client to 5.1.4.
+- Modify `IndioWrapper` class to work with Indico 5.x.
+- Update `Snapshot` class to account for updated target spans.
+- Update Add Model calls to align with 5.1.4 components.
+
+
+## v2.0.1 - 2022-05-20
+
+### Added
+
+- Feature in `FileProcessing` class to read and return file as JSON.
+- Feature in `Highlighter` class to redact and replace highlights with spoofed data.
+- `Download` class to support downloading resources from an Indico Cluster.
+
+### Changed
+
+- Upgrade client to 5.1.3.
+- Update SDK calls for Indico 5.x compatibility.
+
+### Removed
+
+- `FindRelated` class in `indico_wrapper`.
+
+
+## v1.2.2 - 2022-03-03
+
+### Added
+
+- Feature in `Positioning` class to calculate overlap between two bounding boxes on the
+  same page.
+
+### Changed
+
+- Update metrics plot to order ascending based on latest model.
+
+### Fixed
+
+- Optional dependencies to support M1 installation.
+
+
+## v1.2.0 - 2022-01-06
+
+### Added
+
+- Distance measurements in the prediction `Positioning` class.
+- Features on the `Extractions` class:
+  - predictions that are removed by any method are saved in an attribute if they're
+    needed for logs, etc.; get all text values for a particular label,
+  - get most common text value for a particular label.
+- Better exception handling for workflow submissions and more flexibility on format of
+  what is returned (allows custom response JSON to avoid the `WorkflowResult` class).
+
+
+## v1.1.2 - 2021-12-06
+
+### Added
+
+- Update functionality for large dataset creation.
+- Batch options allow for more reliable dataset uploads.
+
+
+## v1.1.1 - 2021-12-06
+
+### Added
+
+- Ability to include metadata with highlighter.
+- Ability to split large snapshots into smaller files.
+
+
+## v1.0.8 - 2021-11-15
+
+### Added
+
+- Line plot for number of samples in metrics class.
+
+### Changed
+
+- Update `Highlighting` class with new flexibility and bookmarks replacing table of
+  contents.
+
+
+## v1.0.7 - 2021-11-09
+
+### Added
+
+- `Positioning` class to assist in relative prediction location validation.
+- Number of samples labeled to metrics class.
+
+### Removed
+
+- Teach classes in `indico_wrapper`.
+
+
+## v1.0.5 - 2021-09-21
+
+### Added
+
+- Classes for model comparison and model improvement.
+- Plotting functionality for model comparison.
+
+
+## v1.0.3 - 2021-08-16
+
+### Added
+
+- Find from questionnaire ID added to finder class.
+- ModelGroupPredict support.
+- Module to get metrics for all models in a group.
+- Multi color highlighting and annotations for PDF highlighting.
+- Staggered dataset upload feature for large doc datasets.
+- Default retry functionality for certain API calls.
+- Additional snapshot features.
+
+### Fixed
+
+- `wait` keyword argument added to submit review method.
+- Better support for dataset creation / adding files to teach tasks.
+
+
+## v1.0.2 - 2021-06-15
+
+### Added
+
+- PDF manipulation features.
+- Support for classification predictions.
+
+### Fixed
+
+- Dependency installation.
+
+
+## v1.0.1 - 2021-06-02
+
+### Added
+
+- Snapshot merging / manipulation.
+- Class for highlighting extractions onto source PDFs and adding table of contents.
+
+### Fixed
+
+- Row Association now also sorting on 'bbtop'.
+
+
+[v7.2.0]: https://github.com/IndicoDataSolutions/zapper/compare/v6.14.2...v7.2.0
+[v6.14.2]: https://github.com/IndicoDataSolutions/zapper/compare/v6.14.1...v6.14.2
+[v6.14.1]: https://github.com/IndicoDataSolutions/zapper/compare/v6.14.0...v6.14.1
+[v6.14.0]: https://github.com/IndicoDataSolutions/zapper/tree/v6.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,3 +166,25 @@ This is the first major version release tested to work on Indico 6.X.
 * Added support for imported models using IPA 7.2 `component_metadata` section.
 * Parse and preserve full span information for `Unbundling` predictions.
 * Add `group = next(group)` idiom.
+
+## 7.2.0 6/17/25
+
+### Added
+
+* Unified support for `dict`, JSON `str`, and JSON `bytes` as loadable types in
+  `results.load()`, `results.load_async()`, `etloutput.load()`, and
+  `etloutput.load_async()`.
+
+### Changed
+
+* Renamed `model`, `ModelGroup`, and `ModelGroupType` to `task`, `Task`, and `TaskType`
+  in the `results` module.
+* Table OCR is now automatically loaded when present
+  (`AutoReviewPoller(..., load_tables=True)` and `etloutput.load(..., tables=True)` are
+  now the default).
+
+### Removed
+
+* v1 result file code paths in the `results` module.
+* v1 ETL output code paths in the `etloutput` module.
+* 6.X edge cases in the `results` module.

--- a/indico_toolkit/__init__.py
+++ b/indico_toolkit/__init__.py
@@ -21,4 +21,4 @@ __all__ = (
     "ToolkitStaggeredLoopError",
     "ToolkitStatusError",
 )
-__version__ = "6.14.2"
+__version__ = "7.2.0"

--- a/indico_toolkit/etloutput/__init__.py
+++ b/indico_toolkit/etloutput/__init__.py
@@ -30,7 +30,7 @@ __all__ = (
     "TokenNotFoundError",
 )
 
-Loadable: TypeAlias = "dict[str, object] | str | bytes"
+Loadable: TypeAlias = "dict[str, object] | list[object] | str | bytes"
 Readable = TypeVar("Readable")
 URI: TypeAlias = str
 
@@ -47,9 +47,9 @@ def load(
     Load `etl_output` as an `EtlOutput` dataclass.
 
     `etl_output` can be a dict, JSON string/bytes, or something that can be read by
-    `reader` to produce either.
+    `reader` to produce a loadable type.
 
-    `reader` must be able to handle Indico storage URIs.
+    `reader` must be able to load Indico storage URIs as lists or JSON strings/bytes.
 
     Use `text`, `tokens`, and `tables` to specify what not to load.
 
@@ -108,9 +108,9 @@ async def load_async(
     Load `etl_output` as an `EtlOutput` dataclass.
 
     `etl_output` can be a dict, JSON string/bytes, or something that can be read by
-    `reader` to produce either.
+    `reader` to produce a loadable type.
 
-    `reader` must be able to handle Indico storage URIs.
+    `reader` must be able to load Indico storage URIs as lists or JSON strings/bytes.
 
     Use `text`, `tokens`, and `tables` to specify what not to load.
 

--- a/indico_toolkit/etloutput/__init__.py
+++ b/indico_toolkit/etloutput/__init__.py
@@ -1,7 +1,7 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias, TypeVar
 
 from ..results import NULL_BOX, NULL_SPAN, Box, Span
-from ..results.utils import get, has
+from ..results.utils import get, has, json_loaded, str_decoded
 from .cell import Cell, CellType
 from .errors import EtlOutputError, TableCellNotFoundError, TokenNotFoundError
 from .etloutput import EtlOutput
@@ -11,7 +11,6 @@ from .token import Token
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
-    from typing import Any
 
 __all__ = (
     "Box",
@@ -31,20 +30,28 @@ __all__ = (
     "TokenNotFoundError",
 )
 
+Loadable: TypeAlias = "dict[str, object] | str | bytes"
+Readable = TypeVar("Readable")
+URI: TypeAlias = str
+
 
 def load(
-    etl_output_uri: str,
+    etl_output: "Loadable | Readable",
     *,
-    reader: "Callable[..., Any]",
+    reader: "Callable[[Readable | URI], Loadable]",
     text: bool = True,
     tokens: bool = True,
     tables: bool = True,
 ) -> EtlOutput:
     """
-    Load `etl_output_uri` as an `EtlOutput` dataclass. A `reader` function must be
-    supplied to read JSON files from disk, storage API, or Indico client.
+    Load `etl_output` as an `EtlOutput` dataclass.
 
-    Use `text`, `tokens`, and `tables` to specify what to load.
+    `etl_output` can be a dict, JSON string/bytes, or something that can be read by
+    `reader` to produce either.
+
+    `reader` must be able to handle Indico storage URIs.
+
+    Use `text`, `tokens`, and `tables` to specify what not to load.
 
     ```
     result = results.load(submission.result_file, reader=read_uri)
@@ -55,21 +62,34 @@ def load(
     }
     ```
     """
-    etl_output = reader(etl_output_uri)
+    if not isinstance(etl_output, dict):
+        if (isinstance(etl_output, str) and etl_output.startswith("{")) or (
+            isinstance(etl_output, bytes) and etl_output.startswith(b"{")
+        ):
+            etl_output = json_loaded(etl_output)
+        else:
+            etl_output = json_loaded(reader(etl_output))  # type: ignore[arg-type]
+
     pages = get(etl_output, list, "pages")
 
     if text and has(pages, str, 0, "text"):
-        text_pages = map(lambda page: reader(get(page, str, "text")), pages)
+        text_pages = map(
+            lambda page: str_decoded(reader(get(page, str, "text"))), pages  # type: ignore[arg-type]
+        )
     else:
         text_pages = ()  # type: ignore[assignment]
 
     if tokens and has(pages, str, 0, "tokens"):
-        token_dict_pages = map(lambda page: reader(get(page, str, "tokens")), pages)
+        token_dict_pages = map(
+            lambda page: json_loaded(reader(get(page, str, "tokens"))), pages
+        )
     else:
         token_dict_pages = ()  # type: ignore[assignment]
 
     if tables and has(pages, str, 0, "tables"):
-        table_dict_pages = map(lambda page: reader(get(page, str, "tables")), pages)
+        table_dict_pages = map(
+            lambda page: json_loaded(reader(get(page, str, "tables"))), pages
+        )
     else:
         table_dict_pages = ()  # type: ignore[assignment]
 
@@ -77,18 +97,22 @@ def load(
 
 
 async def load_async(
-    etl_output_uri: str,
+    etl_output: "Loadable | Readable",
     *,
-    reader: "Callable[..., Awaitable[Any]]",
+    reader: "Callable[[Readable | URI], Awaitable[Loadable]]",
     text: bool = True,
     tokens: bool = True,
     tables: bool = True,
 ) -> EtlOutput:
     """
-    Load `etl_output_uri` as an `EtlOutput` dataclass. A `reader` coroutine must be
-    supplied to read JSON files from disk, storage API, or Indico client.
+    Load `etl_output` as an `EtlOutput` dataclass.
 
-    Use `text`, `tokens`, and `tables` to specify what to load.
+    `etl_output` can be a dict, JSON string/bytes, or something that can be read by
+    `reader` to produce either.
+
+    `reader` must be able to handle Indico storage URIs.
+
+    Use `text`, `tokens`, and `tables` to specify what not to load.
 
     ```
     result = await results.load_async(submission.result_file, reader=read_uri)
@@ -99,21 +123,34 @@ async def load_async(
     }
     ```
     """
-    etl_output = await reader(etl_output_uri)
+    if not isinstance(etl_output, dict):
+        if (isinstance(etl_output, str) and etl_output.startswith("{")) or (
+            isinstance(etl_output, bytes) and etl_output.startswith(b"{")
+        ):
+            etl_output = json_loaded(etl_output)
+        else:
+            etl_output = json_loaded(await reader(etl_output))  # type: ignore[arg-type]
+
     pages = get(etl_output, list, "pages")
 
     if text and has(pages, str, 0, "text"):
-        text_pages = [await reader(get(page, str, "text")) for page in pages]
+        text_pages = [
+            str_decoded(await reader(get(page, str, "text"))) for page in pages  # type: ignore[arg-type]
+        ]
     else:
         text_pages = ()  # type: ignore[assignment]
 
     if tokens and has(pages, str, 0, "tokens"):
-        token_dict_pages = [await reader(get(page, str, "tokens")) for page in pages]
+        token_dict_pages = [
+            json_loaded(await reader(get(page, str, "tokens"))) for page in pages
+        ]
     else:
         token_dict_pages = ()  # type: ignore[assignment]
 
     if tables and has(pages, str, 0, "tables"):
-        table_dict_pages = [await reader(get(page, str, "tables")) for page in pages]
+        table_dict_pages = [
+            json_loaded(await reader(get(page, str, "tables"))) for page in pages
+        ]
     else:
         table_dict_pages = ()  # type: ignore[assignment]
 

--- a/indico_toolkit/polling/autoreview.py
+++ b/indico_toolkit/polling/autoreview.py
@@ -96,8 +96,8 @@ class AutoReviewPoller:
                 *(self._reap_workers() for _ in range(self._worker_count)),
             )
 
-    async def _retrieve_storage_object(self, url: str) -> object:
-        return await self._client_call(RetrieveStorageObject(url))
+    async def _retrieve_storage_object(self, uri: str) -> "Any":
+        return await self._client_call(RetrieveStorageObject(uri))
 
     async def _spawn_workers(self) -> None:
         """

--- a/indico_toolkit/results/result.py
+++ b/indico_toolkit/results/result.py
@@ -4,6 +4,7 @@ from itertools import chain
 
 from . import predictions as prediction
 from .document import Document
+from .errors import ResultError
 from .normalization import normalize_result_dict
 from .predictionlist import PredictionList
 from .predictions import Prediction
@@ -49,6 +50,11 @@ class Result:
         """
         Create a `Result` from a result file dictionary.
         """
+        file_version = get(result, int, "file_version")
+
+        if file_version != 3:
+            raise ResultError(f"unsupported file version `{file_version}`")
+
         normalize_result_dict(result)
 
         submission_id = get(result, int, "submission_id")

--- a/indico_toolkit/results/utils.py
+++ b/indico_toolkit/results/utils.py
@@ -1,5 +1,9 @@
+import json
 from collections.abc import Iterable, Iterator
-from typing import Callable, TypeVar
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from typing import Any, Callable
 
 Value = TypeVar("Value")
 
@@ -47,6 +51,18 @@ def has(result: object, value_type: "type[Value]", *keys: "str | int") -> bool:
     return isinstance(result, value_type)
 
 
+def json_loaded(value: "Any") -> "Any":
+    """
+    Ensure `value` has been loaded as JSON.
+    """
+    value = str_decoded(value)
+
+    if isinstance(value, str):
+        value = json.loads(value)
+
+    return value
+
+
 def nfilter(
     predicates: "Iterable[Callable[[Value], bool]]", values: "Iterable[Value]"
 ) -> "Iterator[Value]":
@@ -73,3 +89,13 @@ def omit(dictionary: object, *keys: str) -> "dict[str, Value]":
         for key, value in dictionary.items()
         if key not in keys
     }  # fmt: skip
+
+
+def str_decoded(value: str | bytes) -> str:
+    """
+    Ensure `value` has been decoded to a string.
+    """
+    if isinstance(value, bytes):
+        value = value.decode()
+
+    return value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 readme = "README.md"
 urls = { source = "https://github.com/IndicoDataSolutions/Indico-Solutions-Toolkit" }
 requires-python = ">=3.10"
-version = "6.14.2"
+version = "7.2.0"
 dependencies = ["indico-client (>=6.14.0,<7.0.0)"]
 
 [project.optional-dependencies]

--- a/tests/etloutput/test_files.py
+++ b/tests/etloutput/test_files.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 import pytest
@@ -8,23 +7,20 @@ from indico_toolkit import etloutput
 data_folder = Path(__file__).parent.parent / "data" / "etloutput"
 
 
-def read_uri(uri: str) -> object:
+def read_uri(uri: str | Path) -> str:
+    uri = str(uri)
     storage_folder_path = uri.split("/storage/submission/")[-1]
     file_path = data_folder / storage_folder_path
-
-    if file_path.suffix.casefold() == ".json":
-        return json.loads(file_path.read_text())
-    else:
-        return file_path.read_text()
+    return file_path.read_text()
 
 
-async def read_uri_async(uri: str) -> object:
+async def read_uri_async(uri: str | Path) -> str:
     return read_uri(uri)
 
 
 @pytest.mark.parametrize("etl_output_file", list(data_folder.rglob("etl_output.json")))
 def test_file_load(etl_output_file: Path) -> None:
-    etl_output = etloutput.load(str(etl_output_file), reader=read_uri)
+    etl_output = etloutput.load(etl_output_file, reader=read_uri)
     page_count = len(etl_output.text_on_page)
     char_count = len(etl_output.text)
     token_count = len(etl_output.tokens)
@@ -38,7 +34,7 @@ def test_file_load(etl_output_file: Path) -> None:
 
 @pytest.mark.parametrize("etl_output_file", list(data_folder.rglob("etl_output.json")))
 async def test_file_load_async(etl_output_file: Path) -> None:
-    etl_output = await etloutput.load_async(str(etl_output_file), reader=read_uri_async)
+    etl_output = await etloutput.load_async(etl_output_file, reader=read_uri_async)
     page_count = len(etl_output.text_on_page)
     char_count = len(etl_output.text)
     token_count = len(etl_output.tokens)
@@ -53,7 +49,7 @@ async def test_file_load_async(etl_output_file: Path) -> None:
 @pytest.mark.parametrize("etl_output_file", list(data_folder.rglob("etl_output.json")))
 def test_file_load_disable_values(etl_output_file: Path) -> None:
     etl_output = etloutput.load(
-        str(etl_output_file),
+        etl_output_file,
         reader=read_uri,
         text=False,
         tokens=False,
@@ -73,7 +69,7 @@ def test_file_load_disable_values(etl_output_file: Path) -> None:
 @pytest.mark.parametrize("etl_output_file", list(data_folder.rglob("etl_output.json")))
 async def test_file_load_disable_values_async(etl_output_file: Path) -> None:
     etl_output = await etloutput.load_async(
-        str(etl_output_file),
+        etl_output_file,
         reader=read_uri_async,
         text=False,
         tokens=False,

--- a/tests/etloutput/test_token_table_cell.py
+++ b/tests/etloutput/test_token_table_cell.py
@@ -1,4 +1,3 @@
-import json
 from dataclasses import replace
 from pathlib import Path
 
@@ -18,19 +17,16 @@ data_folder = Path(__file__).parent.parent / "data" / "etloutput"
 etl_output_file = data_folder / "4725" / "111924" / "110239" / "etl_output.json"
 
 
-def read_uri(uri: str) -> object:
+def read_uri(uri: str | Path) -> bytes:
+    uri = str(uri)
     storage_folder_path = uri.split("/storage/submission/")[-1]
     file_path = data_folder / storage_folder_path
-
-    if file_path.suffix.casefold() == ".json":
-        return json.loads(file_path.read_text())
-    else:
-        return file_path.read_text()
+    return file_path.read_bytes()
 
 
 @pytest.fixture(scope="module")
 def etl_output() -> EtlOutput:
-    return etloutput.load(str(etl_output_file), reader=read_uri)
+    return etloutput.load(etl_output_file, reader=read_uri)
 
 
 @pytest.fixture

--- a/tests/results/test_files.py
+++ b/tests/results/test_files.py
@@ -17,10 +17,10 @@ def test_file_load(result_file: Path) -> None:
 
 @pytest.mark.parametrize("result_file", list(data_folder.glob("*.json")))
 async def test_file_load_async(result_file: Path) -> None:
-    async def path_read_text_async(path: Path) -> str:
-        return path.read_text()
+    async def path_read_bytes_async(path: Path) -> bytes:
+        return path.read_bytes()
 
-    result = await results.load_async(result_file, reader=path_read_text_async)
+    result = await results.load_async(result_file, reader=path_read_bytes_async)
     result.pre_review.to_changes(result)
     assert result.submission_id
 


### PR DESCRIPTION
This PR enhances the dataclass loading functions to make them consistent with each other and simpler to use.

- `results.load(object, reader=...)`
- `results.load_async(object, reader=...)`
- `etloutput.load(object, reader=...)`
- `etloutput.load_async(object, reader=...)`

All 4 now support loading already-parsed JSON dicts/lists as well as JSON strings/bytes--both as the first `object` argument and as return values from `reader`.

This primarily simplifies the `reader` argument for `etloutput` when reading from disk or `StorageClient`. Previously the implementation had to have separate cases for text and JSON URIs.

```python
async def read_uri(uri: str) -> Any:
    if uri.casefold().endswith(".json"):
        return await storage_client.read(StorageObject.from_uri(uri, "json"))
    elif uri.casefold().endswith(".txt"):
        return (await storage_client.read(StorageObject.from_uri(uri, "raw"))).decode()
    else:
        return await storage_client.read(StorageObject.from_uri(uri, "raw"))
```

Whereas now the implementation can always return `str` or `bytes` for all URIs, making it easy to read from disk with `Path.read_text()`, GraphQL with `RetrieveStorageObject`, or S3 with `StorageClient`.

```python
results.load(result_file_path, reader=Path.read_text)
results.load(result_file_uri, reader=lambda uri: client.call(RetrieveStorageObject(uri)))
await etloutput.load_async(etl_output_uri, reader=lambda uri: storage_client.read(StorageObject.from_uri(uri, "raw")))
```
